### PR TITLE
Publish NuGet packages using GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish NuGet package
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup .NET Core Build Environment
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+      - name: Build packages
+        run: dotnet build --configuration Release
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Pack NuGet packages
+        run: dotnet pack -c Release -o out
+      - name: Push NuGet packages to nuget.org
+        run: dotnet nuget push **/*.nupkg
+               --api-key ${{ secrets.NUGET_API_KEY }}
+               --source https://api.nuget.org/v3/index.json

--- a/DataTables.NetStandard.TemplateMapper/DataTables.NetStandard.TemplateMapper.csproj
+++ b/DataTables.NetStandard.TemplateMapper/DataTables.NetStandard.TemplateMapper.csproj
@@ -14,6 +14,8 @@
     <RepositoryUrl>https://github.com/Namoshek/DataTables.NetStandard.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>datatables, datatables.net, queryable, linq, efcore, entity-framework-core</PackageTags>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The PR introduces a new workflow to publish built packages using GitHub Actions, but only when source code is tagged on `master`.