### PR TITLE
Bump version to v1.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup .NET Core build environment
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '2.2.207'
+        dotnet-version: '3.1.x'
     - name: Build the projects
       run: dotnet build --configuration Release
     - name: Pack the publish package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,3 +22,4 @@ jobs:
         run: dotnet nuget push **/*.nupkg
                --api-key ${{ secrets.NUGET_API_KEY }}
                --source https://api.nuget.org/v3/index.json
+               --skip-duplicate

--- a/DataTables.NetStandard.TemplateMapper/DataTables.NetStandard.TemplateMapper.csproj
+++ b/DataTables.NetStandard.TemplateMapper/DataTables.NetStandard.TemplateMapper.csproj
@@ -1,19 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.2.0</Version>
-    <AssemblyVersion>0.0.2.0</AssemblyVersion>
-    <FileVersion>0.0.2.0</FileVersion>
+    <Version>1.0.0</Version>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
     <Authors>Namoshek</Authors>
     <Company>Namoshek</Company>
-    <Description>Additional template mappers for the DataTables.NetStandard package.</Description>
-    <PackageLicenseUrl>https://github.com/Namoshek/DataTables.NetStandard/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageId>DataTables.NetStandard.TemplateMapper</PackageId>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Namoshek/DataTables.NetStandard</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Namoshek/DataTables.NetStandard.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
+    <Description>Additional template mappers for the DataTables.NetStandard package.</Description>
     <PackageTags>datatables, datatables.net, queryable, linq, efcore, entity-framework-core</PackageTags>
+    <RepositoryType>git</RepositoryType>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>


### PR DESCRIPTION
The PR updates the version to v1.0.0, since the package is stable enough now. Also we want to avoid conflicts with existing tags due to the clone of the repository from [`DataTables.NetStandard`](https://github.com/Namoshek/DataTables.NetStandard).